### PR TITLE
✨ [#110] 사용자별 댓글 목록 조회용 쿼리 추가

### DIFF
--- a/backend/src/main/java/com/Devim/backend/controller/user/UserController.java
+++ b/backend/src/main/java/com/Devim/backend/controller/user/UserController.java
@@ -222,6 +222,24 @@ public class UserController {
         return ResponseEntity.ok(commentService.getCommentsByUser(userNo, pageRequestDto));
     }
 
+    @Operation(summary = "사용자별 댓글 목록 조회 (최신순)", description = "특정 사용자가 작성한 댓글 목록을 최신순으로 페이지네이션하여 조회합니다.",
+            parameters = {
+                    @Parameter(name = "userNo", description = "사용자 번호", required = true),
+                    @Parameter(name = "page", description = "페이지 번호", required = false, example = "1"),
+                    @Parameter(name = "size", description = "페이지당 댓글 수", required = false, example = "10")
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping("/{userNo}/comments/desc")
+    public ResponseEntity<PageResponseDto<CommentListResponseDto>> getUserCommentsDesc(
+            @PathVariable("userNo") long userNo,
+            @ModelAttribute PageRequestDto pageRequestDto) {
+        return ResponseEntity.ok(commentService.getCommentsByUserDesc(userNo, pageRequestDto));
+    }
+
     @Operation(summary = "게시글 작성수 TOP 5 사용자 조회", description = "게시글을 가장 많이 작성한 사용자 5명을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공")

--- a/backend/src/main/java/com/Devim/backend/domain/comment/CommentListResponseDto.java
+++ b/backend/src/main/java/com/Devim/backend/domain/comment/CommentListResponseDto.java
@@ -6,6 +6,8 @@ import lombok.Data;
 @Data
 public class CommentListResponseDto {
     private long commentNo;
+    private long boardNo;
+    private int boardTypeNo;
     private String commentContent;
     private String writerName;
     private String profileImagePath;

--- a/backend/src/main/java/com/Devim/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/Devim/backend/repository/CommentRepository.java
@@ -23,4 +23,6 @@ public interface CommentRepository {
     List<MonthlyCountDto> countMonthlyComments();
 
     PageResponseDto<CommentListResponseDto> findByUserNo(long userNo, PageRequestDto pageRequest);
+
+    PageResponseDto<CommentListResponseDto> findByUserNoDesc(long userNo, PageRequestDto pageRequest);
 }

--- a/backend/src/main/java/com/Devim/backend/repository/mybatis/CommentMapper.java
+++ b/backend/src/main/java/com/Devim/backend/repository/mybatis/CommentMapper.java
@@ -30,4 +30,6 @@ public interface CommentMapper {
     List<CommentListResponseDto> findByUserNo(@Param("userNo") long userNo, @Param("pageRequest") PageRequestDto pageRequest);
 
     long countByUserNo(@Param("userNo") long userNo);
+
+    List<CommentListResponseDto> findByUserNoDesc(@Param("userNo") long userNo, @Param("pageRequest") PageRequestDto pageRequest);
 }

--- a/backend/src/main/java/com/Devim/backend/repository/mybatis/MyBatisCommentRepository.java
+++ b/backend/src/main/java/com/Devim/backend/repository/mybatis/MyBatisCommentRepository.java
@@ -58,4 +58,11 @@ public class MyBatisCommentRepository implements CommentRepository {
         long totalCount = commentMapper.countByUserNo(userNo);
         return new PageResponseDto<>(dtoList, pageRequest, totalCount);
     }
+
+    @Override
+    public PageResponseDto<CommentListResponseDto> findByUserNoDesc(long userNo, PageRequestDto pageRequest) {
+        List<CommentListResponseDto> dtoList = commentMapper.findByUserNoDesc(userNo, pageRequest);
+        long totalCount = commentMapper.countByUserNo(userNo); // Re-using countByUserNo
+        return new PageResponseDto<>(dtoList, pageRequest, totalCount);
+    }
 }

--- a/backend/src/main/java/com/Devim/backend/service/comment/CommentService.java
+++ b/backend/src/main/java/com/Devim/backend/service/comment/CommentService.java
@@ -23,4 +23,6 @@ public interface CommentService {
     List<MonthlyCountDto> countMonthlyComments();
 
     PageResponseDto<CommentListResponseDto> getCommentsByUser(long userNo, PageRequestDto pageRequestDto);
+
+    PageResponseDto<CommentListResponseDto> getCommentsByUserDesc(long userNo, PageRequestDto pageRequestDto);
 }

--- a/backend/src/main/java/com/Devim/backend/service/comment/CommentServiceImpl.java
+++ b/backend/src/main/java/com/Devim/backend/service/comment/CommentServiceImpl.java
@@ -69,4 +69,9 @@ public class CommentServiceImpl implements CommentService{
     public PageResponseDto<CommentListResponseDto> getCommentsByUser(long userNo, PageRequestDto pageRequestDto) {
         return commentRepository.findByUserNo(userNo, pageRequestDto);
     }
+
+    @Override
+    public PageResponseDto<CommentListResponseDto> getCommentsByUserDesc(long userNo, PageRequestDto pageRequestDto) {
+        return commentRepository.findByUserNoDesc(userNo, pageRequestDto);
+    }
 }

--- a/backend/src/main/resources/mappers/CommentMapper.xml
+++ b/backend/src/main/resources/mappers/CommentMapper.xml
@@ -41,12 +41,15 @@
         SELECT
             c."comment_no" AS commentNo,
             c."board_no" AS boardNo,
+            b."board_type_no" AS boardTypeNo,
             c."comment_content" AS commentContent,
             u."name" AS writerName,
             u."profile_image_path" AS profileImagePath,
             c."created_dt" AS createdDt,
             c."delete_flag" AS deleteFlag
-        FROM "comment" c JOIN "user" u ON c."writer" = u."user_no"
+        FROM "comment" c
+        JOIN "user" u ON c."writer" = u."user_no"
+        JOIN "board" b ON c."board_no" = b."board_no"
         WHERE c."writer" = #{userNo} AND c."delete_flag" = 0
         ORDER BY c."comment_no" ASC
         OFFSET (#{pageRequest.page} - 1) * #{pageRequest.size} ROWS FETCH NEXT #{pageRequest.size} ROWS ONLY
@@ -56,6 +59,24 @@
         SELECT COUNT(*)
         FROM "comment"
         WHERE "writer" = #{userNo} AND "delete_flag" = 0
+    </select>
+
+    <select id="findByUserNoDesc" parameterType="map" resultType="com.Devim.backend.domain.comment.CommentListResponseDto">
+        SELECT
+            c."comment_no" AS commentNo,
+            c."board_no" AS boardNo,
+            b."board_type_no" AS boardTypeNo,
+            c."comment_content" AS commentContent,
+            u."name" AS writerName,
+            u."profile_image_path" AS profileImagePath,
+            c."created_dt" AS createdDt,
+            c."delete_flag" AS deleteFlag
+        FROM "comment" c
+        JOIN "user" u ON c."writer" = u."user_no"
+        JOIN "board" b ON c."board_no" = b."board_no"
+        WHERE c."writer" = #{userNo} AND c."delete_flag" = 0
+        ORDER BY c."comment_no" DESC
+        OFFSET (#{pageRequest.page} - 1) * #{pageRequest.size} ROWS FETCH NEXT #{pageRequest.size} ROWS ONLY
     </select>
 
     <update id="update" parameterType="com.Devim.backend.domain.comment.Comment">

--- a/docs/SettingQuery.sql
+++ b/docs/SettingQuery.sql
@@ -87,6 +87,4 @@ INSERT INTO "board_type" (
     "board_name"
 ) VALUES ( 3, '공지사항' );
 
-INSERT INTO "user_role" ("user_no", "role")
-VALUES (1, 'ROLE_ADMIN');
 


### PR DESCRIPTION
## Issues
- closed #110

## ✔️  Check-list
- [ ✔️ ] : Label을 지정해 주세요.
- [ ✔️ ] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
사용자별 댓글 목록 조회를 위한 Dto 수정
 \- boardNo, boardTypeNo 추가
 \- 최신순으로 정렬하여 리스트출력하는 쿼리 추가

## 📷 Screenshot

## 📚 Reference
