### PR TITLE
✨ [#113] 컨트롤러 인증된 사용자 정보 받기

### DIFF
--- a/backend/src/main/java/com/Devim/backend/controller/board/BoardController.java
+++ b/backend/src/main/java/com/Devim/backend/controller/board/BoardController.java
@@ -4,6 +4,7 @@ import com.Devim.backend.domain.board.*;
 import com.Devim.backend.domain.common.MonthlyCountDto;
 import com.Devim.backend.domain.common.PageRequestDto;
 import com.Devim.backend.domain.common.PageResponseDto;
+import com.Devim.backend.jwt.JWTUserPrincipal;
 import com.Devim.backend.service.board.BoardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,7 +32,7 @@ public class BoardController {
 
     @Operation(
             summary = "게시글 생성",
-            description = "새 게시글을 생성합니다. (임시: X-USER-NO 헤더로 작성자 ID 전달)",
+            description = "새 게시글을 생성합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     description = "게시글 생성 요청 바디",
@@ -42,15 +44,15 @@ public class BoardController {
     })
     @PostMapping
     public ResponseEntity<Void> create(@Validated @RequestBody BoardCreateRequestDto requestDto,
-                                       @RequestHeader("X-USER-NO") Long userNo) {
-        Long id = boardService.create(requestDto, userNo);
+                                       @AuthenticationPrincipal JWTUserPrincipal userPrincipal) {
+        Long id = boardService.create(requestDto, userPrincipal.getUserNo());
         return ResponseEntity.created(URI.create("/api/v1/boards/" + id)).build();
     }
 
     
     @Operation(
-            summary = "게시글 상세 조회",
-            description = "boardNo로 게시글을 조회합니다. (임시: X-USER-NO 헤더로 현재 사용자 ID 전달)",
+            summary = "게시글 단건 조회",
+            description = "boardNo로 게시글을 조회합니다.",
             parameters = {
                     @io.swagger.v3.oas.annotations.Parameter(name = "boardNo", description = "게시글 번호", example = "101", required = true)
             }
@@ -61,7 +63,8 @@ public class BoardController {
     })
     @GetMapping("/{boardNo}")
     public ResponseEntity<BoardDetailResponseDto> get(@PathVariable("boardNo") Long boardNo,
-                                                      @RequestHeader(value = "X-USER-NO", required = false) Long currentUserNo) {
+                                                      @AuthenticationPrincipal JWTUserPrincipal userPrincipal) {
+        Long currentUserNo = (userPrincipal != null) ? userPrincipal.getUserNo() : null;
         return ResponseEntity.ok(boardService.get(boardNo, currentUserNo));
     }
 

--- a/backend/src/main/java/com/Devim/backend/controller/comment/CommentController.java
+++ b/backend/src/main/java/com/Devim/backend/controller/comment/CommentController.java
@@ -7,6 +7,7 @@ import com.Devim.backend.domain.comment.PageResponseDtoOfCommentListResponseDto;
 import com.Devim.backend.domain.common.MonthlyCountDto;
 import com.Devim.backend.domain.common.PageRequestDto;
 import com.Devim.backend.domain.common.PageResponseDto;
+import com.Devim.backend.jwt.JWTUserPrincipal;
 import com.Devim.backend.service.comment.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +34,7 @@ public class CommentController {
 
     @Operation(
             summary = "댓글 생성",
-            description = "새 댓글을 생성합니다. (임시: X-USER-NO 헤더로 작성자 ID 전달)",
+            description = "새 댓글을 생성합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     description = "댓글 생성 요청 바디",
@@ -44,8 +46,8 @@ public class CommentController {
     })
     @PostMapping
     public ResponseEntity<Void> create(@Validated @RequestBody CommentCreateRequestDto requestDto,
-                                       @RequestHeader("X-USER-NO") Long userNo) {
-        Long id = commentService.create(requestDto, userNo);
+                                       @AuthenticationPrincipal JWTUserPrincipal userPrincipal) {
+        Long id = commentService.create(requestDto, userPrincipal.getUserNo());
         return ResponseEntity.created(URI.create("/api/v1/comments/" + id)).build();
     }
 

--- a/backend/src/main/java/com/Devim/backend/controller/likes/LikesController.java
+++ b/backend/src/main/java/com/Devim/backend/controller/likes/LikesController.java
@@ -1,5 +1,6 @@
 package com.Devim.backend.controller.likes;
 
+import com.Devim.backend.jwt.JWTUserPrincipal;
 import com.Devim.backend.service.likes.LikesService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Likes Controller", description = "좋아요 기능 API")
@@ -18,7 +20,7 @@ public class LikesController {
 
     private final LikesService likesService;
 
-    @Operation(summary = "좋아요/좋아요 취소", description = "게시글 또는 댓글에 좋아요를 누르거나 취소합니다. (임시: X-USER-NO 헤더로 사용자 ID 전달)",
+    @Operation(summary = "좋아요/좋아요 취소", description = "게시글 또는 댓글에 좋아요를 누르거나 취소합니다.",
             parameters = {
                     @Parameter(name = "targetType", description = "좋아요 대상 타입 (board 또는 comment)", example = "board", required = true),
                     @Parameter(name = "targetId", description = "좋아요 대상 ID (게시글 번호 또는 댓글 번호)", example = "101", required = true)
@@ -33,12 +35,12 @@ public class LikesController {
     public ResponseEntity<Void> toggleLike(
             @PathVariable("targetType") String targetType,
             @PathVariable("targetId") long targetId,
-            @RequestHeader("X-USER-NO") Long userNo) {
+            @AuthenticationPrincipal JWTUserPrincipal userPrincipal) {
 
         // TODO: targetType 유효성 검사 (board, comment 등)
         // TODO: targetId가 실제로 존재하는지 검사
 
-        likesService.toggleLike(userNo, targetId, targetType);
+        likesService.toggleLike(userPrincipal.getUserNo(), targetId, targetType);
         return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
## Issues
- closed #113

## ✔️  Check-list
- [ ✔️ ] : Label을 지정해 주세요.
- [ ✔️ ] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
컨트롤러에서 임시 사용자 헤더로 받던 부분 수정
인증된 토큰을 통해 UserNo를 받아서 찾도록 수정됨

## 📷 Screenshot
예시)
<img width="851" height="126" alt="image" src="https://github.com/user-attachments/assets/7af52864-49c5-40b3-8261-2786029aa41b" />

## 📚 Reference
